### PR TITLE
Fix Movie struct in GetIMDBMovieDetails

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ type Movie struct {
 	Cast           map[string]string `xmlrpc:"cast"`
 	Directors      map[string]string `xmlrpc:"directors"`
 	Writers        map[string]string `xmlrpc:"writers"`
-	Awards         string            `xmlrpc:"awards"`
+	Awards         []string          `xmlrpc:"awards"`
 	Genres         []string          `xmlrpc:"genres"`
 	Countries      []string          `xmlrpc:"country"`
 	Languages      []string          `xmlrpc:"language"`

--- a/client_test.go
+++ b/client_test.go
@@ -80,6 +80,33 @@ func ExampleClient_IMDBSearchByID() {
 	// 403358: Night.Watch.2004.720p.BluRay.x264-SiNNERS.srt
 }
 
+func ExampleClient_GetIMDBMovieDetails() {
+	c, err := NewClient()
+	if err != nil {
+		fmt.Printf("can't create client: %s\n", err)
+		return
+	}
+
+	err = c.LogIn("", "", "")
+	if err != nil {
+		fmt.Printf("can't login: %s\n", err)
+		return
+	}
+
+	id := "0403358"
+
+	time.Sleep(1 * time.Second)
+	movie, err := c.GetIMDBMovieDetails(id)
+	if err != nil {
+		fmt.Printf("can't get details: %s\n", err)
+		return
+	}
+	fmt.Printf("%s: %s - id %s - awards '%s'\n", id, movie.Title, movie.ID, movie.Awards[0])
+
+	// Output:
+	// 0403358: Nochnoy dozor - id 0403358 - awards '2 wins & 5 nominations.'
+}
+
 func TestIMDBSearchByIDManyTimes(t *testing.T) {
 	c, err := NewClient()
 	if err != nil {


### PR DESCRIPTION
The Award field in the Movie struct seems to be an array of string
instead of just a string despite what is written in the documentation
http://trac.opensubtitles.org/projects/opensubtitles/wiki/XmlRpcGetIMDBMovieDetails