### PR TITLE
IMDB filted search, Hash Search & encoding issues

### DIFF
--- a/client.go
+++ b/client.go
@@ -472,6 +472,9 @@ func hashString(hash uint64) string {
 
 // Tries to guess the character encoding by its name
 // (or whatever Opensubtitles thinks its name is)
+// if Opensubtitles encoding is not well formatted (common) utf-8 is used as a fallback
 func encodingFromName(name string) (encoding.Encoding, error) {
-	return htmlindex.Get(name)
+	result,e:=return htmlindex.Get(name)
+	if e!=nil{  return htmlindex.Get("utf-8") }
+	return result,e
 }

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package osdb
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -95,6 +96,56 @@ func (c *Client) IMDBSearchByID(ids []string, langs []string) (Subtitles, error)
 		)
 	}
 
+	return c.SearchSubtitles(&params)
+}
+
+// IMDBSearchByIDFiltered Searches for a movie or tv episode by IMDB code. Set isMovie to true to ignore the season and episode
+// otherwise the search try to find a subtitle that matches the season and episode supplied. Note: When looking for Episodes by the
+// Series IMDB code, if you don't filter by episode/season - the result might include too many subtitles to return and thus
+// some results will be ommited.
+func (c *Client) IMDBSearchByIDFiltered(imdbCode string, isMovie bool, season uint, episode uint, lang []string) (Subtitles, error) {
+	if !isMovie {
+		params := []interface{}{
+			c.Token,
+			[]struct {
+				Imdbid        string `xmlrpc:"imdbid"`
+				Sublanguageid string `xmlrpc:"sublanguageid"`
+				Season        int64  `xmlrpc:"season"`
+				Episode       int64  `xmlrpc:"episode"`
+			}{{
+				imdbCode,
+				strings.Join(lang, ","),
+				int64(season),
+				int64(episode),
+			}},
+		}
+		return c.SearchSubtitles(&params)
+	} else {
+		return c.IMDBSearchByID([]string{imdbCode}, lang)
+	}
+}
+
+// HashSearch Searches for subtitles that match a specific hash/size/language combination.
+// This function does not require the path of the movie file, just the hash/size values.
+func (c *Client) HashSearch(hash uint64, size int64, langs []string) (Subtitles, error) {
+	if hash == 0 || size == 0 {
+		return nil, errors.New("called OS search by Hash with no hash value")
+	}
+	if size < 15000 {
+		return nil, errors.New("called OS search by Hash with a small file")
+	}
+	params := []interface{}{
+		c.Token,
+		[]struct {
+			Hash  string `xmlrpc:"moviehash"`
+			Size  int64  `xmlrpc:"moviebytesize"`
+			Langs string `xmlrpc:"sublanguageid"`
+		}{{
+			fmt.Sprintf("%016x", hash),
+			size,
+			strings.Join(langs, ","),
+		}},
+	}
 	return c.SearchSubtitles(&params)
 }
 

--- a/client.go
+++ b/client.go
@@ -474,7 +474,9 @@ func hashString(hash uint64) string {
 // (or whatever Opensubtitles thinks its name is)
 // if Opensubtitles encoding is not well formatted (common) utf-8 is used as a fallback
 func encodingFromName(name string) (encoding.Encoding, error) {
-	result,e:=return htmlindex.Get(name)
-	if e!=nil{  return htmlindex.Get("utf-8") }
-	return result,e
+	result, e := htmlindex.Get(name)
+	if e != nil {
+		return htmlindex.Get("utf-8")
+	}
+	return result, e
 }


### PR DESCRIPTION
Added the following:

-   a filtered search by imdb, to allow filtering the results by season & episodes.  Otherwise searching by a TV series imdb code returns too many results that need to be filtered (and in many season - some results are omitted due to length of response).
-  a search for subtitles by hash code without providing the file path.  Avoids the need to hash the local file for each search.  
-  Many of the encodings in osdb database are malformed and do not conform to the http syntax.  In such cases the default utf-8 encoding is used instead of returning an error (and not being able to download the subtitle).

Many thanks
Raz